### PR TITLE
A custom User model does not always have a username field.

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -98,6 +98,7 @@ class Command(BaseCommand):
         # This could be /improved by looking up the last notified person
         last_sent = None
         context = {'user': None,
+                   'username': None,
                    'notifications': None,
                    'digest': None,
                    'site': Site.objects.get_current()}
@@ -133,6 +134,8 @@ class Command(BaseCommand):
 
             for setting in user_settings:
                 context['user'] = setting.user
+                context['username'] = getattr(
+                    setting.user, setting.user.USERNAME_FIELD)
                 context['notifications'] = []
                 # get the index of the tuple corresponding to the interval and
                 # get the string name

--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -75,7 +75,8 @@ class Settings(models.Model):
     )
 
     def __str__(self):
-        obj_name = _("Settings for %s") % self.user.username
+        obj_name = _("Settings for %s") % getattr(
+            self.user, self.user.USERNAME_FIELD)
         return obj_name.encode('utf-8')
 
     class Meta:
@@ -116,7 +117,8 @@ class Subscription(models.Model):
     )
 
     def __str__(self):
-        obj_name = _("Subscription for: %s") % str(self.settings.user.username)
+        obj_name = _("Subscription for: %s") % str(
+            getattr(self.settings.user, self.settings.user.USERNAME_FIELD))
         return obj_name.encode('utf-8')
 
     class Meta:

--- a/django_nyt/templates/emails/notification_email_message.txt
+++ b/django_nyt/templates/emails/notification_email_message.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% load url from future %}{% blocktrans with user.username as username %}Dear {{ username }},{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{% load url from future %}{% blocktrans with username as username %}Dear {{ username }},{% endblocktrans %}
 
 {% blocktrans with site.name as site %}These are the {{ digest }} notifications from {{ site }}.{% endblocktrans %}
 {% for n in notifications %}


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#django.contrib.auth.models.CustomUser.USERNAME_FIELD