### PR TITLE
Fix bug with __str__ in python 3

### DIFF
--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -81,7 +81,7 @@ class Settings(models.Model):
     def __str__(self):
         obj_name = _("Settings for %s") % getattr(
             self.user, self.user.USERNAME_FIELD)
-        return obj_name.encode('utf-8')
+        return obj_name
 
     class Meta:
         db_table = settings.DB_TABLE_PREFIX + '_settings'
@@ -164,9 +164,9 @@ class Subscription(models.Model):
     )
 
     def __str__(self):
-        obj_name = _("Subscription for: %s") % str(
+        obj_name = _("Subscription for: %s") % (
             getattr(self.settings.user, self.settings.user.USERNAME_FIELD))
-        return obj_name.encode('utf-8')
+        return obj_name
 
     class Meta:
         db_table = settings.DB_TABLE_PREFIX + '_subscription'
@@ -281,7 +281,7 @@ class Notification(models.Model):
         return objects_created
 
     def __str__(self):
-        return "%s: %s" % (str(self.user), self.message)
+        return "%s: %s" % (self.user, self.message)
 
     class Meta:
         db_table = settings.DB_TABLE_PREFIX + '_notification'


### PR DESCRIPTION
The __str__ methods of Settings and Subscription returned
bytes when running in python 3 and caused errors because the str function expects
(unicode) strings in python 3.

This pull request fixes the bug.
I made sure It also works for non-ascii translation strings (russian) in python 2 as mentioned in b1e0b23cd7b4e4e.

The commit also fixes problems in python 2 when the username of a user has non-ascii
characters.

This is the code I used to test the bug and bugfix, using the test-project.

```
# -*- coding: utf-8 -*-
import django.utils.translation
django.utils.translation.activate('ru')

from django.contrib.auth.models import User
u = User.objects.first()
u.username = 'Øystein'
u.save()

from django_nyt.models import Settings, Subscription, Notification
print(Settings.objects.all())
print(Subscription.objects.all())
print(Notification.objects.all())
```
