### PR TITLE
Accept explicitly WebSocket connections.

### DIFF
--- a/django_nyt/consumers.py
+++ b/django_nyt/consumers.py
@@ -19,6 +19,7 @@ def ws_connect(message):
     Connected to websocket.connect
     """
     logger.debug("Adding new connection for user {}".format(message.user))
+    message.reply_channel.send({"accept": True})
 
     for subscription in models.Subscription.objects.filter(settings__user=message.user):
         Group(


### PR DESCRIPTION
Like mentioned in the channels documentation we need to explicitly accept websocket connections in order to connect to the server. https://channels.readthedocs.io/en/stable/getting-started.html#groups