### PR TITLE
Added apps DjangoNytConfig

### DIFF
--- a/django_nyt/__init__.py
+++ b/django_nyt/__init__.py
@@ -7,6 +7,8 @@ _disable_notifications = False
 VERSION = "1.0b6"
 __version__ = VERSION
 
+default_app_config = "django_nyt.apps.DjangoNytConfig"
+
 
 def notify(*args, **kwargs):
     """

--- a/django_nyt/apps.py
+++ b/django_nyt/apps.py
@@ -1,0 +1,9 @@
+from __future__ import unicode_literals
+
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+
+class DjangoNytConfig(AppConfig):
+    name = "django_nyt"
+    verbose_name = _("Django Nyt")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,7 @@ INSTALLED_APPS
 
    INSTALLED_APPS = (
        ...
-       'django_nyt'
+       'django_nyt.apps.DjangoNytConfig'
        ...
    )
 


### PR DESCRIPTION
PR taken out of https://github.com/benjaoming/django-nyt/pull/55, which is django >= 1.8 compatible.