### PR TITLE
Use django.utils.six instead of the external six module.

### DIFF
--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import six
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django_nyt import settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 django>=1.8
-six

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ LINT =
 commands = python -W all:"":"":"":0 -m coverage run --source=django_nyt runtests.py
 deps =
   coverage
-  six==1.6.1
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
   django110: Django>=1.10,<1.11


### PR DESCRIPTION
Feel free to close it if the external `six` module is indeed intended.