### PR TITLE
Deprecate django_nyt.urls.get_pattern

### DIFF
--- a/django_nyt/urls.py
+++ b/django_nyt/urls.py
@@ -20,7 +20,9 @@ def get_pattern(app_name=app_name, namespace="nyt"):
     """Every url resolution takes place as "nyt:view_name".
        https://docs.djangoproject.com/en/dev/topics/http/urls/#topics-http-reversing-url-namespaces
     """
-    if DJANGO_VERSION < (1, 9):
-        return urlpatterns, app_name, namespace
-    else:
-        return include('django_nyt.urls',)
+    import warnings
+    warnings.warn(
+        'django_nyt.urls.get_pattern is deprecated and will be removed in next version,'
+        ' just use include(\'django_nyt.urls\')', DeprecationWarning
+    )
+    return include('django_nyt.urls')

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,16 +37,6 @@ You need to add the following patterns to get JSON views. You need to add it to 
 
 .. code-block:: python
 
-   from django_nyt.urls import get_pattern as get_nyt_pattern
-   urlpatterns += patterns('',
-       url(r'^notifications/', get_nyt_pattern()),
-   )
-
-Or, for Django >= 1.8:
-
-.. code-block:: python
-
-   from django_nyt.urls import get_pattern as get_nyt_pattern
    urlpatterns += [
-       url(r'^notifications/', get_nyt_pattern()),
+       url(r'^notifications/', include('django_nyt.urls')),
    ]

--- a/test-project/testproject/urls.py
+++ b/test-project/testproject/urls.py
@@ -11,6 +11,7 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', admin.site.urls),
+    url(r'^nyt/', include('django_nyt.urls')),
     url(r'', include('testapp.urls')),
 ]
 
@@ -21,10 +22,3 @@ if settings.DEBUG:
             'document_root': settings.MEDIA_ROOT,
         }),
     ]
-
-
-from django_nyt.urls import get_pattern
-
-urlpatterns += [
-    url(r'^nyt/', get_pattern()),
-]


### PR DESCRIPTION
Deprecate `django_nyt.urls.get_pattern()` helper.